### PR TITLE
Fix startup tests to check metrics

### DIFF
--- a/templates/extensions/usd_composer.setup/template/{{python_module_path}}/tests/test_app_startup.py
+++ b/templates/extensions/usd_composer.setup/template/{{python_module_path}}/tests/test_app_startup.py
@@ -59,13 +59,14 @@ class TestAppStartup(AsyncTestCase):
         for _ in range(60):
             await omni.kit.app.get_app().next_update_async()
 
-        self.app_startup_time(self.id())
-        self.assertTrue(True)
+        startup_time = self.app_startup_time(self.id())
+        self.assertGreater(startup_time, 0)
 
     async def test_l1_app_startup_warning_count(self):
         """Get the count of warnings during startup - send to nvdf"""
         for _ in range(60):
             await omni.kit.app.get_app().next_update_async()
 
-        self.app_startup_warning_count(self.id())
-        self.assertTrue(True)
+        warning_count, error_count = self.app_startup_warning_count(self.id())
+        self.assertGreaterEqual(warning_count, 0)
+        self.assertGreaterEqual(error_count, 0)

--- a/templates/extensions/usd_explorer.setup/template/{{python_module_path}}/tests/test_app_startup.py
+++ b/templates/extensions/usd_explorer.setup/template/{{python_module_path}}/tests/test_app_startup.py
@@ -49,13 +49,14 @@ class TestAppStartup(AsyncTestCase):
         for _ in range(60):
             await omni.kit.app.get_app().next_update_async()
 
-        self.app_startup_time(self.id())
-        self.assertTrue(True)
+        startup_time = self.app_startup_time(self.id())
+        self.assertGreater(startup_time, 0)
 
     async def test_l1_app_startup_warning_count(self):
         """Get the count of warnings during startup - send to nvdf"""
         for _ in range(60):
             await omni.kit.app.get_app().next_update_async()
 
-        self.app_startup_warning_count(self.id())
-        self.assertTrue(True)
+        warning_count, error_count = self.app_startup_warning_count(self.id())
+        self.assertGreaterEqual(warning_count, 0)
+        self.assertGreaterEqual(error_count, 0)


### PR DESCRIPTION
## Summary
- capture return values from `app_startup_time` and `app_startup_warning_count`
- assert startup time is positive and warning/error counts are non-negative

## Testing
- `pytest -q` *(fails: pytest not installed)*