### PR TITLE
Fix comment formatting in template test

### DIFF
--- a/templates/extensions/usd_viewer.setup/template/{{python_module_path}}/tests/test_app_extensions.py
+++ b/templates/extensions/usd_viewer.setup/template/{{python_module_path}}/tests/test_app_extensions.py
@@ -14,7 +14,7 @@ from omni.kit.test import AsyncTestCase
 
 class TestUSDViewerExtensions(AsyncTestCase):
     """Class to hold USD Viewer setup extension tests."""
-    # NOTE: Function pulled to remove dependency from omni.kit.core.tests"""
+    # NOTE: Function pulled to remove dependency from omni.kit.core.tests
 
     def _validate_extensions_load(self):
         failures = []


### PR DESCRIPTION
## Summary
- tweak comment syntax in USD viewer test template

## Testing
- `pytest -q` *(fails: command not found)*