### PR TITLE
Add CharacterViewer animation support

### DIFF
--- a/source/animation_utils.py
+++ b/source/animation_utils.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import carb
+import omni.usd
+import omni.timeline
+from pxr import Usd
+
+
+def play_animation(anim_name: str, loop: bool = True) -> None:
+    """Play the animation clip using the Omniverse timeline.
+
+    Parameters
+    ----------
+    anim_name : str
+        Name of the animation clip prim under ``/Root/Animations``.
+    loop : bool, optional
+        Whether the timeline should loop playback, by default ``True``.
+    """
+    stage = omni.usd.get_context().get_stage()
+    if stage is None:
+        carb.log_warn("No stage available for playback")
+        return
+
+    clip_path = f"/Root/Animations/{anim_name}"
+    clip_prim = stage.GetPrimAtPath(clip_path)
+    if not clip_prim or not clip_prim.IsValid():
+        carb.log_warn(f"Animation prim not found: {clip_path}")
+        return
+
+    start_attr = clip_prim.GetAttribute("startTimeCode")
+    end_attr = clip_prim.GetAttribute("endTimeCode")
+    if not start_attr or not end_attr:
+        carb.log_warn(f"Animation {anim_name} missing timecode attributes")
+        return
+
+    start = start_attr.Get()
+    end = end_attr.Get()
+
+    timeline = omni.timeline.get_timeline_interface()
+    timeline.set_looping(loop)
+    timeline.set_playback_range(start, end)
+    timeline.set_current_time(start)
+    timeline.play()
+
+    if not loop:
+
+        def _on_tick(event):
+            if event.type == int(omni.timeline.TimelineEventType.TICK):
+                if timeline.get_current_time() >= end:
+                    timeline.pause()
+                    timeline.remove_callback(_sub)
+
+        _sub = timeline.get_timeline_event_stream().create_subscription_to_pop(_on_tick)

--- a/tests/test_animation_utils.py
+++ b/tests/test_animation_utils.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "source"))
+import animation_utils
+
+
+def test_play_animation_signature():
+    assert callable(animation_utils.play_animation)
+    with pytest.raises(TypeError):
+        animation_utils.play_animation()

--- a/web-viewer/README.md
+++ b/web-viewer/README.md
@@ -1,0 +1,20 @@
+# Web Viewer Animation Support
+
+This folder provides a small example for playing character animations with [Three.js](https://threejs.org/).
+
+## CharacterViewer
+
+The `CharacterViewer` class handles loading a character model and clothing, then plays animations with an `AnimationMixer`.
+
+### Usage
+
+```ts
+import { CharacterViewer } from './characterViewer';
+
+const viewer = new CharacterViewer(scene);
+await viewer.loadCharacter('path/to/character.glb');
+await viewer.loadClothing('path/to/clothing.glb');
+viewer.playAnimation('Walk');
+```
+
+Call `viewer.update(delta)` on each frame to update the animation mixer.

--- a/web-viewer/characterViewer.ts
+++ b/web-viewer/characterViewer.ts
@@ -1,0 +1,70 @@
+import * as THREE from 'three';
+import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
+export class CharacterViewer {
+    private scene: THREE.Scene;
+    private mixer: THREE.AnimationMixer | null = null;
+    private animations: THREE.AnimationClip[] = [];
+    private character: THREE.Object3D | null = null;
+    private skeleton: THREE.Skeleton | null = null;
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+    }
+
+    async loadCharacter(url: string): Promise<void> {
+        const loader = new GLTFLoader();
+        const gltf: GLTF = await loader.loadAsync(url);
+        this.character = gltf.scene;
+        this.scene.add(this.character);
+
+        gltf.scene.traverse((child: THREE.Object3D) => {
+            if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+                const skinned = child as THREE.SkinnedMesh;
+                this.skeleton = skinned.skeleton;
+            }
+        });
+
+        if (gltf.animations && gltf.animations.length) {
+            this.mixer = new THREE.AnimationMixer(gltf.scene);
+            this.animations = gltf.animations;
+        }
+    }
+
+    async loadClothing(url: string): Promise<void> {
+        if (!this.character || !this.skeleton) {
+            throw new Error('Character must be loaded before clothing');
+        }
+        const loader = new GLTFLoader();
+        const gltf: GLTF = await loader.loadAsync(url);
+        gltf.scene.traverse((child: THREE.Object3D) => {
+            if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+                const mesh = child as THREE.SkinnedMesh;
+                mesh.bind(this.skeleton!, mesh.bindMatrix);
+            }
+        });
+        this.character.add(gltf.scene);
+    }
+
+    playAnimation(animationName: string): void {
+        if (!this.mixer) {
+            console.warn('No animations loaded');
+            return;
+        }
+        const clip = THREE.AnimationClip.findByName(this.animations, animationName);
+        if (!clip) {
+            console.warn(`Animation ${animationName} not found`);
+            return;
+        }
+        this.mixer.stopAllAction();
+        const action = this.mixer.clipAction(clip);
+        action.reset();
+        action.play();
+    }
+
+    update(delta: number): void {
+        if (this.mixer) {
+            this.mixer.update(delta);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add example Three.js `CharacterViewer` for playing animations
- document animation usage for the web viewer
- add Python `play_animation` helper for Omniverse timeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'carb')*